### PR TITLE
fix(battery): mark voltage failsafe params reboot required

### DIFF
--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -187,6 +187,7 @@ parameters:
                 0: Disabled
                 1: Enabled
             default: 0
+            reboot_required: true
 
         BAT_V_FS_THR:
             description:
@@ -201,6 +202,7 @@ parameters:
             decimal: 2
             increment: 0.01
             default: 3.60
+            reboot_required: true
 
         BAT_V_FS_DELAY:
             description:
@@ -216,6 +218,7 @@ parameters:
             decimal: 1
             increment: 0.5
             default: 10.0
+            reboot_required: true
 
         BAT_V_FS_HYST:
             description:
@@ -231,3 +234,4 @@ parameters:
             decimal: 2
             increment: 0.01
             default: 0.10
+            reboot_required: true


### PR DESCRIPTION
## Summary

- Mark all `BAT_V_FS_*` voltage-failsafe parameters as reboot-required.

## Rationale

The battery module reads these settings through its parameter update path. Marking them reboot-required prevents a changed setting from being mistaken for an immediately active failsafe configuration during flight.

## Validation

- `ninja -C build/cubepilot_cubeorangeplus_default parameters.xml`
